### PR TITLE
Svy 11381 ability to call handlers from serverside script

### DIFF
--- a/sablo/src/main/java/org/sablo/BaseWebObject.java
+++ b/sablo/src/main/java/org/sablo/BaseWebObject.java
@@ -904,6 +904,11 @@ public abstract class BaseWebObject implements IWebObjectContext
 		return eventHandlers.containsKey(event);
 	}
 
+	public Set<String> getAllEventHandlerNames()
+	{
+		return eventHandlers.keySet();
+	}
+
 	/**
 	 * Called when this object will not longer be used - to release any held resources/remove listeners.
 	 */

--- a/sablo/src/main/java/org/sablo/websocket/utils/JSONUtils.java
+++ b/sablo/src/main/java/org/sablo/websocket/utils/JSONUtils.java
@@ -351,6 +351,15 @@ public class JSONUtils
 			IPropertyType< ? > type = pd.getType();
 			if (type instanceof IPropertyConverterForBrowser< ? >)
 			{
+				if (type instanceof IClassPropertyType)
+				{
+					//check if already the desired type, can happen when calling the handler from the serverside script
+					if (((IClassPropertyType)type).getTypeClass().isInstance(newValue))
+					{
+						return newValue;
+					}
+				}
+
 				return ((IPropertyConverterForBrowser)type).fromJSON(newValue, oldValue, pd, dataConversionContext, returnValueAdjustedIncommingValue);
 			}
 		}


### PR DESCRIPTION
Small adjustments to Sable in order to implement the ability to expose handlers in the serverside script

added getAllHandlerNames
prevent argument conversion if the argument type is already the desired type